### PR TITLE
Fix multiple day events not appearing & rendering

### DIFF
--- a/app/src/lib/components/Calendar.svelte
+++ b/app/src/lib/components/Calendar.svelte
@@ -3,6 +3,7 @@
 	import CalendarItem from '$lib/components/CalendarItem.svelte';
 
 	interface EventData {
+		id: string,
 		title: string;
 		sport: string;
 		startTime: string;

--- a/app/src/lib/components/Calendar.svelte
+++ b/app/src/lib/components/Calendar.svelte
@@ -57,6 +57,11 @@
 		setInterval(updateTimeLocation, 1000 * 30);
 	});
 
+	const isUTCDateEqual = (dayA: Date, dayB: Date) =>
+		dayA.getUTCDate() == dayB.getUTCDate() &&
+		dayA.getUTCMonth() == dayB.getUTCMonth() &&
+		dayA.getUTCFullYear() == dayB.getUTCFullYear();
+
 	// returns the position of a specific event on the event grid
 	function calculatePos(event: EventData) {
 		let startTime = new Date(event.startTime);
@@ -64,6 +69,11 @@
 
 		// round down start time
 		startTime.setUTCMinutes(Math.floor(startTime.getUTCMinutes() / 15) * 15);
+		// The start time is not on this day, therefore it can be assumed that it's on some previous day
+		if (!isUTCDateEqual(startTime, selectedDate)) {
+			startTime.setUTCHours(calendarStartHour);
+		}
+
 		const startRow = getRow(startTime);
 
 		// clamp end time

--- a/app/src/lib/components/CalendarItem.svelte
+++ b/app/src/lib/components/CalendarItem.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { redirect } from '@sveltejs/kit';
+
 	interface CalendarItemProps {
 		colStart: number;
 		rowStart: number;
@@ -6,15 +8,18 @@
 		title: string;
 		location: string;
 		sport: string;
+		id: string,
 	}
 
-	let { colStart, rowStart, rowSpan, title, location, sport }: CalendarItemProps = $props();
+	let { colStart, rowStart, rowSpan, title, location, sport, id }: CalendarItemProps = $props();
 </script>
 
-<div
-	class="col-span-1 p-[3px]"
+<a
+	class="col-span-1 p-[3px] block"
 	style="grid-column-start: {colStart};
 		grid-row: {rowStart} / span {rowSpan};"
+	href="/sports?eventId={id}"
+
 >
 	<div
 		class="bg-accent/90 font-alata flex h-full w-full flex-col justify-between overflow-hidden rounded-md px-2 py-1 text-xs"
@@ -41,4 +46,4 @@
 			</div>
 		{/if}
 	</div>
-</div>
+</a>

--- a/app/src/routes/calendar/+page.svelte
+++ b/app/src/routes/calendar/+page.svelte
@@ -69,10 +69,11 @@
 		let maxTime = -Infinity;
 
 		for (let event of events) {
-			const dateNum = getDate(event.startTime).getTime();
+			const startDateMs = getDate(event.startTime).getTime();
+			const endDateMs = getDate(event.endTime).getTime();
 
-			if (minTime > dateNum) minTime = dateNum;
-			if (maxTime < dateNum) maxTime = dateNum;
+			if (minTime > startDateMs) minTime = startDateMs;
+			if (maxTime < endDateMs) maxTime = endDateMs;
 
 			if (!sports.includes(event.sport)) {
 				sports.push(event.sport);
@@ -142,7 +143,9 @@
 	const applyFilters = (firstLoadValue = false) => {
 		firstLoad = firstLoadValue;
 		events = fullEvents.filter(
-			(value) => filters.sports[value.sport] && filters.days[getEventDay(value.startTime) - 1]
+			(value) => filters.sports[value.sport] && 
+				// If the day spans more than the entire day, check against the end time
+				(filters.days[getEventDay(value.startTime) - 1] || filters.days[getEventDay(value.endTime) - 1])
 		);
 	};
 

--- a/db/hooks/validate.js
+++ b/db/hooks/validate.js
@@ -3,8 +3,11 @@
 const validate = ({ collectionName, startTime, endTime }) => {
 	// Validate events records
 	if (collectionName == "events") {
-		if (new Date(startTime).getTime() > new Date(endTime).getTime()) {
+		let [startTimeMs, endTimeMs] = [new Date(startTime).getTime(), new Date(endTime).getTime()];
+		if (startTimeMs > endTimeMs) {
 			return "The start time of the event is after the end time!";
+		} else if (startTimeMs == endTimeMs) {
+			return "The start time of the event is equal to the end time!";
 		}
 	}
 	// Assume everything else is always valid

--- a/db/hooks/validate.js
+++ b/db/hooks/validate.js
@@ -3,11 +3,8 @@
 const validate = ({ collectionName, startTime, endTime }) => {
 	// Validate events records
 	if (collectionName == "events") {
-		let [startTimeMs, endTimeMs] = [new Date(startTime).getTime(), new Date(endTime).getTime()];
-		if (startTimeMs > endTimeMs) {
+		if (new Date(startTime).getTime() > new Date(endTime).getTime()) {
 			return "The start time of the event is after the end time!";
-		} else if (startTimeMs == endTimeMs) {
-			return "The start time of the event is equal to the end time!";
 		}
 	}
 	// Assume everything else is always valid


### PR DESCRIPTION
When a multi-day event exists, endTime is not compared against -> number of days is lower than expected: Fixed
When selected day does not match the calendar would render based on the startTime of that previous day: Fixed
Test, but I don't think there's too much that can go wrong with it
Just check if times match expected times or not 